### PR TITLE
Make header handling generic and version-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ It uses ECDSA (Elliptic Curve Digital Signature Algorithm) to ensure the integri
 
 - Sign/Verify firmware images with ECDSA (NIST P-256 or brainpool 256).
 - Support for HSM Token (PKCS#11).
-- Currently supports only STM32MP15x MPU firmware image headers.
+- Detects the [STM32 header version](https://wiki.st.com/stm32mpu/wiki/STM32_header_for_binary_files) of the firmware image.
+- Currently supports only the header v1 used by the STM32MP15x lines; the header v2 used by the STM32MP13x lines and STM32MP2 series is detected but not supported yet.
 
 ## Requirements
 

--- a/stm32mp-dump-header.py
+++ b/stm32mp-dump-header.py
@@ -21,20 +21,40 @@
 import struct
 import argparse
 
-# Define the STM32 header format
-STM32_HEADER_FORMAT = '<4s64s10I64s83sB'  # Matches the provided C struct layout
-STM32_HEADER_SIZE = struct.calcsize(STM32_HEADER_FORMAT)  # Calculate header size
+# STM32 header formats, keyed by the major version byte of hdr_version
+# https://wiki.st.com/stm32mpu/wiki/STM32_header_for_binary_files
+# v1 (STM32MP15x lines) is the only one implemented so far.
+STM32_HEADER_V1_FORMAT = '<4s64s10I64s83sB'
+STM32_HEADER_V1_SIZE = struct.calcsize(STM32_HEADER_V1_FORMAT)
+
+STM32_HEADER_SIZE = STM32_HEADER_V1_SIZE  # Largest header we can parse
+
+def get_header_version(header):
+    """
+    Returns (major, minor) from the hdr_version field at offset 0x48.
+    """
+    hdr_version = struct.unpack_from('<I', header, 0x48)[0]
+    return (hdr_version >> 16) & 0xFF, (hdr_version >> 8) & 0xFF
 
 def unpack_stm32_header(header):
     """
-    Unpacks the STM32Header binary data into a dictionary.
+    Unpacks the STM32 header binary data into a dictionary.
     """
+    if header[0:4] != b'STM2':
+        print(f"Error: not an STM32 header, magic: {header[0:4]!r}")
+        return None
+
+    major, minor = get_header_version(header)
+    if major != 1:
+        print(f"Error: STM32 header v{major}.{minor} is not supported yet (only v1, STM32MP15x lines)")
+        return None
+
     try:
-        unpacked_header = struct.unpack(STM32_HEADER_FORMAT, header)
+        unpacked_header = struct.unpack(STM32_HEADER_V1_FORMAT, header)
     except struct.error as e:
         print(f"Error unpacking header: {e}")
         print(f"Header length: {len(header)}")
-        print(f"Expected length: {STM32_HEADER_SIZE}")
+        print(f"Expected length: {STM32_HEADER_V1_SIZE}")
         return None
 
     # Create a dictionary with unpacked fields
@@ -42,7 +62,7 @@ def unpack_stm32_header(header):
         'magic': unpacked_header[0].decode('ascii').strip('\x00'),
         'signature': unpacked_header[1],
         'checksum': unpacked_header[2],
-        'hdr_version': unpacked_header[3],
+        'hdr_version': f'v{major}.{minor}',
         'length': unpacked_header[4],
         'entry_addr': unpacked_header[5],
         'reserved1': unpacked_header[6],

--- a/stm32mp-gen-image.py
+++ b/stm32mp-gen-image.py
@@ -21,8 +21,12 @@
 import struct
 import argparse
 
-# Define the STM32 header format
+# Define the STM32 header v1 format (STM32MP15x lines)
+# https://wiki.st.com/stm32mpu/wiki/STM32_header_for_binary_files
 STM32_HEADER_FORMAT = '<4s64s10I64s83xB'
+
+# Header version field: byte 1 = minor, byte 2 = major
+STM32_HEADER_VERSION_V1 = 0x00010000
 
 def generate_stm32_header(magic, checksum, hdr_version, length, entry_addr, load_addr, rollback_version, option_flags, ecdsa_algo):
     # Pack the header fields into a binary format
@@ -51,7 +55,7 @@ def generate_stm32_image(output_file, payload):
 
     # Define other header fields
     magic = 'STM2'
-    hdr_version = 1
+    hdr_version = STM32_HEADER_VERSION_V1
     length = len(payload)
     entry_addr = 0x08000000
     load_addr = 0x08000000

--- a/stm32mp-sign-tool.cpp
+++ b/stm32mp-sign-tool.cpp
@@ -48,14 +48,36 @@ static OSSL_PROVIDER* default_provider = nullptr;
 /*******************************************************************
  * https://wiki.st.com/stm32mpu/wiki/STM32_header_for_binary_files *
  *                                                                 *
- * Notes:                                                          *
+ * The STM32 binary header exists in several versions, identified  *
+ * by the major byte of the hdr_version field:                     *
+ * - v1.x (256 bytes): STM32MP15x lines                            *
+ * - v2.x (512 bytes): STM32MP13x lines and STM32MP2 series,       *
+ *   with extension headers (not implemented yet)                  *
+ *                                                                 *
+ * Notes (v1):                                                     *
  * - The signature is calculated over the data starting at offset  *
  *   0x48 (hdr_version field) up to the last byte given by the     *
  *   image_length field (i.e. sizeof(header) + header.length).     *
  * - The ecdsa_pubkey contains the public key (x, y) coordinates   *
  *   of the ECDSA key (64 bytes total).                            *
  *******************************************************************/
-struct STM32Header {
+
+// Fields common to all STM32 header versions (offsets 0x00-0x63)
+struct STM32HeaderCommon {
+    char magic[4];
+    unsigned char signature[64];
+    uint32_t checksum;
+    uint32_t hdr_version; // byte 1: minor, byte 2: major
+    uint32_t length;
+    uint32_t entry_addr;
+    uint32_t reserved1; // Set to 0
+    uint32_t load_addr;
+    uint32_t reserved2; // Set to 0
+    uint32_t rollback_version;
+} __attribute__((packed));
+
+// Header v1 (STM32MP15x lines)
+struct STM32HeaderV1 {
     char magic[4];
     unsigned char signature[64];
     uint32_t checksum;
@@ -73,14 +95,36 @@ struct STM32Header {
     unsigned char binary_type;
 } __attribute__((packed));
 
-STM32Header unpack_stm32_header(const std::vector<unsigned char>& image) {
-    STM32Header header;
-    std::memcpy(&header, image.data(), sizeof(STM32Header));
+enum STM32HeaderVersion {
+    STM32_HEADER_V1 = 1, // STM32MP15x lines
+    STM32_HEADER_V2 = 2, // STM32MP13x lines and STM32MP2 series
+};
+
+// Validate the common header fields and return the header major version,
+// or -1 if the image is too short or does not carry the STM32 magic.
+int get_stm32_header_version(const std::vector<unsigned char>& image) {
+    if (image.size() < sizeof(STM32HeaderCommon)) {
+        std::cerr << "Image too short for an STM32 header: got " << image.size() << " bytes" << std::endl;
+        return -1;
+    }
+    STM32HeaderCommon common;
+    std::memcpy(&common, image.data(), sizeof(common));
+    if (std::strncmp(common.magic, STM32_MAGIC, sizeof(common.magic)) != 0) {
+        std::cerr << "Not an STM32 header (signature FAIL): expected magic '" << STM32_MAGIC
+                  << "', got '" << std::string(common.magic, sizeof(common.magic)) << "'" << std::endl;
+        return -1;
+    }
+    return (common.hdr_version >> 16) & 0xFF;
+}
+
+STM32HeaderV1 unpack_stm32_header_v1(const std::vector<unsigned char>& image) {
+    STM32HeaderV1 header;
+    std::memcpy(&header, image.data(), sizeof(STM32HeaderV1));
     return header;
 }
 
-void repack_stm32_header(std::vector<unsigned char>& image, const STM32Header& header) {
-    std::memcpy(image.data(), &header, sizeof(STM32Header));
+void repack_stm32_header_v1(std::vector<unsigned char>& image, const STM32HeaderV1& header) {
+    std::memcpy(image.data(), &header, sizeof(STM32HeaderV1));
 }
 
 void print_hex(const std::string& label, const std::vector<unsigned char>& data) {
@@ -354,26 +398,20 @@ int hash_pubkey(const char* key_desc, const char* passphrase, const std::string 
  
 }
 
-int verify_stm32_image(const std::vector<unsigned char>& image) {
-    if (image.empty()) {
-        std::cerr << "Image data is empty" << std::endl;
+int verify_stm32_image_v1(const std::vector<unsigned char>& image) {
+    if (image.size() < sizeof(STM32HeaderV1)) {
+        std::cerr << "Image too short for an STM32 v1 header: got " << image.size() << " bytes" << std::endl;
         return -1;
     }
-    STM32Header header = unpack_stm32_header(image);
-
-    if (std::strncmp(header.magic, STM32_MAGIC, sizeof(header.magic)) != 0) {
-        std::cerr << "Not an STM32 header (signature FAIL): expected magic '" << STM32_MAGIC
-                  << "', got '" << std::string(header.magic, sizeof(header.magic)) << "'" << std::endl;
-        return -1;
-    }
+    STM32HeaderV1 header = unpack_stm32_header_v1(image);
 
     // The ROM code hashes exactly 'header.length' bytes after the header (256 bytes), so we must not include trailing padding.
-    size_t hash_end = sizeof(STM32Header) + header.length;
+    size_t hash_end = sizeof(STM32HeaderV1) + header.length;
     if (hash_end > image.size()) {
         std::cerr << "Image too short: expected at least " << hash_end << " bytes, got " << image.size() << std::endl;
         return -1;
     }
-    std::vector<unsigned char> buffer_to_hash(image.begin() + offsetof(STM32Header, hdr_version), image.begin() + static_cast<std::ptrdiff_t>(hash_end));
+    std::vector<unsigned char> buffer_to_hash(image.begin() + offsetof(STM32HeaderV1, hdr_version), image.begin() + static_cast<std::ptrdiff_t>(hash_end));
     std::vector<unsigned char> hash(SHA256_DIGEST_LENGTH);
     if (!SHA256(buffer_to_hash.data(), buffer_to_hash.size(), hash.data())) {
         std::cerr << "Failed to compute SHA-256 hash" << std::endl;
@@ -444,13 +482,25 @@ int verify_stm32_image(const std::vector<unsigned char>& image) {
     }
 }
 
-int sign_stm32_image(std::vector<unsigned char>& image, const char* key_desc, const char* passphrase) {
-    if (image.empty()) {
-        std::cerr << "Image data is empty" << std::endl;
-        return -1;
+int verify_stm32_image(const std::vector<unsigned char>& image) {
+    int hdr_version = get_stm32_header_version(image);
+    switch (hdr_version) {
+        case STM32_HEADER_V1:
+            return verify_stm32_image_v1(image);
+        case STM32_HEADER_V2:
+            std::cerr << "STM32 header v2 (STM32MP13x lines and STM32MP2 series) is not supported yet" << std::endl;
+            return -1;
+        case -1:
+            return -1;
+        default:
+            std::cerr << "Unknown STM32 header version: " << hdr_version << std::endl;
+            return -1;
     }
-    if (!key_desc || std::strlen(key_desc) == 0) {
-        std::cerr << "Key file path is empty" << std::endl;
+}
+
+int sign_stm32_image_v1(std::vector<unsigned char>& image, const char* key_desc, const char* passphrase) {
+    if (image.size() < sizeof(STM32HeaderV1)) {
+        std::cerr << "Image too short for an STM32 v1 header: got " << image.size() << " bytes" << std::endl;
         return -1;
     }
     EVP_PKEY* key = nullptr;
@@ -459,14 +509,7 @@ int sign_stm32_image(std::vector<unsigned char>& image, const char* key_desc, co
         return -1;
     }
 
-    STM32Header header = unpack_stm32_header(image);
-
-    if (std::strncmp(header.magic, STM32_MAGIC, sizeof(header.magic)) != 0) {
-        std::cerr << "Not an STM32 header (signature FAIL): expected magic '" << STM32_MAGIC
-                  << "', got '" << std::string(header.magic, sizeof(header.magic)) << "'" << std::endl;
-        EVP_PKEY_free(key);
-        return -1;
-    }
+    STM32HeaderV1 header = unpack_stm32_header_v1(image);
 
     // Ensure reserved fields are set to 0
     header.reserved1 = 0;
@@ -490,16 +533,16 @@ int sign_stm32_image(std::vector<unsigned char>& image, const char* key_desc, co
     header.ecdsa_algo = static_cast<uint32_t>(algo);
     header.option_flags = 0;
     std::memset(header.padding, 0, sizeof(header.padding)); // Ensure padding is zeroed
-    repack_stm32_header(image, header);
+    repack_stm32_header_v1(image, header);
 
     // The ROM code hashes exactly 'header.length' bytes after the header (256 bytes), so we must not include trailing padding.
-    size_t hash_end = sizeof(STM32Header) + header.length;
+    size_t hash_end = sizeof(STM32HeaderV1) + header.length;
     if (hash_end > image.size()) {
         std::cerr << "Image too short: expected at least " << hash_end << " bytes, got " << image.size() << std::endl;
         EVP_PKEY_free(key);
         return -1;
     }
-    std::vector<unsigned char> buffer_to_hash(image.begin() + offsetof(STM32Header, hdr_version), image.begin() + static_cast<std::ptrdiff_t>(hash_end));
+    std::vector<unsigned char> buffer_to_hash(image.begin() + offsetof(STM32HeaderV1, hdr_version), image.begin() + static_cast<std::ptrdiff_t>(hash_end));
 
     // Sign with the high-level EVP interface so that provider-backed keys
     // (e.g. non-extractable PKCS#11 keys) sign in-place. This produces a
@@ -555,12 +598,39 @@ int sign_stm32_image(std::vector<unsigned char>& image, const char* key_desc, co
     std::memcpy(signature.data() + sizeof(header.signature) - s_bytes.size(), s_bytes.data(), s_bytes.size());
     print_hex("Signature", signature);
 
-    std::memcpy(image.data() + offsetof(STM32Header, signature), signature.data(), signature.size());
+    std::memcpy(image.data() + offsetof(STM32HeaderV1, signature), signature.data(), signature.size());
     ECDSA_SIG_free(sig);
 
     // Verify the signature
-    return verify_stm32_image(image);
+    return verify_stm32_image_v1(image);
 
+}
+
+int sign_stm32_image(std::vector<unsigned char>& image, const char* key_desc, const char* passphrase) {
+    if (image.empty()) {
+        std::cerr << "Image data is empty" << std::endl;
+        return -1;
+    }
+    if (!key_desc || std::strlen(key_desc) == 0) {
+        std::cerr << "Key file path is empty" << std::endl;
+        return -1;
+    }
+    int hdr_version = get_stm32_header_version(image);
+    switch (hdr_version) {
+        case STM32_HEADER_V1:
+            if (verbose) {
+                std::cout << "STM32 header v1 (STM32MP15x lines)" << std::endl;
+            }
+            return sign_stm32_image_v1(image, key_desc, passphrase);
+        case STM32_HEADER_V2:
+            std::cerr << "STM32 header v2 (STM32MP13x lines and STM32MP2 series) is not supported yet" << std::endl;
+            return -1;
+        case -1:
+            return -1;
+        default:
+            std::cerr << "Unknown STM32 header version: " << hdr_version << std::endl;
+            return -1;
+    }
 }
 
 void usage(const char* argv0) {

--- a/stm32mp-sign-tool_test.sh
+++ b/stm32mp-sign-tool_test.sh
@@ -12,6 +12,17 @@ python3 stm32mp-gen-image.py image.stm32 image.bin
 openssl ecparam -name prime256v1 -genkey -out private_key.pem
 ./stm32mp-sign-tool -v -k private_key.pem -i image.stm32 -o image.stm32.signed
 
+# images with an unsupported header version (v2, STM32MP13x/STM32MP2 series) must be rejected
+python3 -c "
+data = bytearray(open('image.stm32', 'rb').read())
+data[0x4A] = 2  # header version major byte
+open('image_v2.stm32', 'wb').write(data)
+"
+if ./stm32mp-sign-tool -v -k private_key.pem -i image_v2.stm32 -o image_v2.stm32.signed; then
+    echo "ERROR: v2 header image should have been rejected"
+    exit 1
+fi
+
 # test plain key file with password
 openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -aes-256-cbc -out private_key.pem -pass pass:pa33w0rd
 ./stm32mp-sign-tool -v -k private_key.pem -p "pa33w0rd" -i image.stm32 -o image.stm32.signed


### PR DESCRIPTION
Detect the STM32 header version (major byte of hdr_version) and dispatch to per-version sign/verify implementations, per the ST binary header spec. Only header v1 (STM32MP15x lines) is implemented. v2 (STM32MP13x/STM32MP2 series) is detected and rejected for now

Thank you for contributing to `stm32mp-sign-tool`!

By submitting this pull request, you confirm that:
- This contribution is your original work or you have the necessary rights to submit it.
- You agree to the terms outlined in the project's Contributor License Agreement (CLA).
